### PR TITLE
Qf output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+testfile.txt

--- a/doc/angryreviewer.txt
+++ b/doc/angryreviewer.txt
@@ -7,12 +7,12 @@
 Author:            Anufriev Roman <https://angryreviewer.com>
 Plugin Homepage:   <https://github.com/anufrievroman/vim-angry-reviewer>
 
-Angry Reviewer plugin for vim and neovim. 
+Angry Reviewer plugin for vim and neovim.
 The plugin provides style suggestions for academic and scientific text.
 It works with any text, but works best with Latex files of scientific papers.
 This plugin is the offline version of the free web-service AngryReviewer.com
 
-USAGE                                                              
+USAGE
 ============================================
 To check text in the buffer run:
 
@@ -21,7 +21,9 @@ To check text in the buffer run:
 
 KEY MAPPING
 ============================================
-Default mapping is at <leader>ar
+Set the default mapping in your vimrc after installing the plugin:
+
+nnoremap <leader>ar :AngryReviewer<cr>
 
 You can remap it for (examples <space>r) as:
 

--- a/err.txt
+++ b/err.txt
@@ -1,0 +1,1 @@
+/bin/bash: line 1: ./sudoku: No such file or directory

--- a/err.txt
+++ b/err.txt
@@ -1,1 +1,0 @@
-/bin/bash: line 1: ./sudoku: No such file or directory

--- a/plugin/angry-reviewer.vim
+++ b/plugin/angry-reviewer.vim
@@ -1031,13 +1031,44 @@ results = main(text)
 #vim.current.buffer[0] = 'SUGGESTIONS FOR YOUR TEXT:'
 #vim.current.buffer.append(results)
 
-# BJC94 : Put `results` into quickfix-window
+# Open results in a quickfix-window TODO
+# vim.command('call setqflist([], "r")')
+# for result in results:
+#     lnum = str() # TODO
+#     qfitem = # TODO
+#     vim.command('call setqflist([{"bufnr": bufnr(""), "lnum": '+lnum+', "text": '+qfitem+'}], "a")')
+
+# Save results to a variable
 vim_cmd_arg =  '[\'' + '\', \''.join(results).replace('"', '\"') + '\']'
-vim.command('let AngryReviewerList = ' + vim_cmd_arg)
-vim.command('call setqflist([], \' \', {\'lines\': AngryReviewerList})')
-vim.command('copen | setlocal wrap linebreak colorcolumn=0')
+vim.command('let b:AngryReviewerList = ' + vim_cmd_arg)
+
+
+# BJC94 : Put `results` into quickfix-window
+# vim.command('call setqflist([], \' \', {\'lines\': AngryReviewerList})')
+# vim.command('copen | setlocal wrap linebreak colorcolumn=0')
+
+#vim.command('echo AngryReviewerList')
+# vim.command('call setqflist([], \' \', {\'lines\': AngryReviewerList})')
+# vim.command('copen | setlocal wrap linebreak colorcolumn=0')
 
 EOF
+
+" return b:AngryReviewerList
+
+
+" IDEA: clear qf list and append elements individually in a loop
+" Inspired by https://stackoverflow.com/a/15276787
+call setqflist([], 'r')
+for l:item in b:AngryReviewerList
+    " echo l:item
+    " get line number
+    let l:lnum = matchstr(l:item, '\d\+', 'regex')
+    let l:qfitem = substitute(l:item, 'Line \d\+\.\s', '', '')
+    " echo l:qfitem l:lnum
+    call setqflist([{'bufnr': bufnr(''), 'lnum': l:lnum, 'text': l:qfitem}], 'a')
+    " sleep 500m
+endfor
+copen | setlocal wrap linebreak colorcolumn=0
 
 endfunction
 

--- a/plugin/angry-reviewer.vim
+++ b/plugin/angry-reviewer.vim
@@ -1032,11 +1032,12 @@ results = main(text)
 #vim.current.buffer.append(results)
 
 # Open results in a quickfix-window TODO
-# vim.command('call setqflist([], "r")')
-# for result in results:
-#     lnum = str() # TODO
-#     qfitem = # TODO
-#     vim.command('call setqflist([{"bufnr": bufnr(""), "lnum": '+lnum+', "text": '+qfitem+'}], "a")')
+vim.command('call setqflist([], "r")')  # clear qflist
+for result in results:
+    re_result = re.search('\d+', result)
+    lnum = re_result[0]
+    qfitem = result[re_result.end()+2:]
+    vim.command('call setqflist([{"bufnr": bufnr(""), "lnum": '+lnum+', "text": \''+qfitem+'\'}], "a")')
 
 # Save results to a variable
 vim_cmd_arg =  '[\'' + '\', \''.join(results).replace('"', '\"') + '\']'
@@ -1058,16 +1059,16 @@ EOF
 
 " IDEA: clear qf list and append elements individually in a loop
 " Inspired by https://stackoverflow.com/a/15276787
-call setqflist([], 'r')
-for l:item in b:AngryReviewerList
-    " echo l:item
-    " get line number
-    let l:lnum = matchstr(l:item, '\d\+', 'regex')
-    let l:qfitem = substitute(l:item, 'Line \d\+\.\s', '', '')
-    " echo l:qfitem l:lnum
-    call setqflist([{'bufnr': bufnr(''), 'lnum': l:lnum, 'text': l:qfitem}], 'a')
-    " sleep 500m
-endfor
+"call setqflist([], 'r')
+"for l:item in b:AngryReviewerList
+"    " echo l:item
+"    " get line number
+"    let l:lnum = matchstr(l:item, '\d\+', 'regex')
+"    let l:qfitem = substitute(l:item, 'Line \d\+\.\s', '', '')
+"    " echo l:qfitem l:lnum
+"    call setqflist([{'bufnr': bufnr(''), 'lnum': l:lnum, 'text': l:qfitem}], 'a')
+"    " sleep 500m
+"endfor
 copen | setlocal wrap linebreak colorcolumn=0
 
 endfunction

--- a/plugin/angry-reviewer.vim
+++ b/plugin/angry-reviewer.vim
@@ -853,7 +853,7 @@ def british_spelling(line, index, english):
     return mistakes
 
 
-def abstract_lenght(text):
+def abstract_length(text):
     '''Find the abstract, check its length and advise if it's too long'''
     # First search for begin{abstract}. If nothing, search for abstract{
     try:
@@ -884,7 +884,7 @@ def abstract_lenght(text):
     return mistakes
 
 
-def title_lenght(text):
+def title_length(text):
     '''Find the title, check its length and advise if it's too long'''
     title = ""
     for line in text:
@@ -994,8 +994,8 @@ def main(text, english='american'):
 
     # General checks
     results = []
-    results += title_lenght(text)
-    results += abstract_lenght(text)
+    results += title_length(text)
+    results += abstract_length(text)
     results += references(text)
     results += intro_patterns(text)
 

--- a/plugin/angry-reviewer.vim
+++ b/plugin/angry-reviewer.vim
@@ -1026,6 +1026,7 @@ text = list(vim.current.buffer)
 results = main(text)
 
 # Open results in a split
+# BJC94: This should be removed if it's decided to stick with qf-list approach
 #vim.command('vsplit e')
 #vim.command('set nonumber')
 #vim.current.buffer[0] = 'SUGGESTIONS FOR YOUR TEXT:'
@@ -1034,15 +1035,18 @@ results = main(text)
 # Open results in a quickfix-window
 vim.command('call setqflist([], "r")')  # clear qflist
 for result in results:
-    re_result = re.search('\d+', result)
-    lnum = re_result[0]
-    qfitem = result[re_result.end()+2:]
-    vim.command('call setqflist([{"bufnr": bufnr(""), "lnum": '+lnum+', "text": \''+qfitem+'\'}], "a")')
-vim.command('copen | setlocal wrap linebreak colorcolumn=0')
+    lnum = '0'
+    qfitem = result
 
-# Save results to a variable (Old snippet, might be useful later?)
-# vim_cmd_arg =  '[\'' + '\', \''.join(results).replace('"', '\"') + '\']'
-# vim.command('let b:AngryReviewerList = ' + vim_cmd_arg)
+    result_has_lnum = re.search('Line .', result)
+    if result_has_lnum:
+        lnum_search = re.search('\d+', result)
+        lnum = lnum_search[0]
+        qfitem = result[lnum_search.end()+2:]  # Clip text following Line xx.\s
+
+    vim.command('call setqflist([{"bufnr": bufnr(""), "lnum": '+lnum+', "text": \''+qfitem+'\'}], "a")')
+
+vim.command('copen | setlocal nonu nornu wrap linebreak colorcolumn=0')
 
 EOF
 
@@ -1053,5 +1057,6 @@ command! -nargs=0 AngryReviewer call AngryReviewer()
 " BJC94: See updated Readme, better to let users set their own mappings
 " nnoremap <leader>ar :AngryReviewer<cr>
 
+" BJC94: This should be removed if it's decided to stick with qf-list approach
 syntax match potionComment "SUGGESTIONS FOR YOUR TEXT:"
 highlight link potionComment Comment

--- a/plugin/angry-reviewer.vim
+++ b/plugin/angry-reviewer.vim
@@ -1026,10 +1026,16 @@ text = list(vim.current.buffer)
 results = main(text)
 
 # Open results in a split
-vim.command('vsplit e')
-vim.command('set nonumber')
-vim.current.buffer[0] = 'SUGGESTIONS FOR YOUR TEXT:'
-vim.current.buffer.append(results)
+#vim.command('vsplit e')
+#vim.command('set nonumber')
+#vim.current.buffer[0] = 'SUGGESTIONS FOR YOUR TEXT:'
+#vim.current.buffer.append(results)
+
+# BJC94 : Put `results` into quickfix-window
+vim_cmd_arg =  '[\'' + '\', \''.join(results).replace('"', '\"') + '\']'
+vim.command('let AngryReviewerList = ' + vim_cmd_arg)
+vim.command('call setqflist([], \' \', {\'lines\': AngryReviewerList})')
+vim.command('copen | setlocal wrap linebreak colorcolumn=0')
 
 EOF
 

--- a/plugin/angry-reviewer.vim
+++ b/plugin/angry-reviewer.vim
@@ -1031,50 +1031,27 @@ results = main(text)
 #vim.current.buffer[0] = 'SUGGESTIONS FOR YOUR TEXT:'
 #vim.current.buffer.append(results)
 
-# Open results in a quickfix-window TODO
+# Open results in a quickfix-window
 vim.command('call setqflist([], "r")')  # clear qflist
 for result in results:
     re_result = re.search('\d+', result)
     lnum = re_result[0]
     qfitem = result[re_result.end()+2:]
     vim.command('call setqflist([{"bufnr": bufnr(""), "lnum": '+lnum+', "text": \''+qfitem+'\'}], "a")')
+vim.command('copen | setlocal wrap linebreak colorcolumn=0')
 
-# Save results to a variable
-vim_cmd_arg =  '[\'' + '\', \''.join(results).replace('"', '\"') + '\']'
-vim.command('let b:AngryReviewerList = ' + vim_cmd_arg)
-
-
-# BJC94 : Put `results` into quickfix-window
-# vim.command('call setqflist([], \' \', {\'lines\': AngryReviewerList})')
-# vim.command('copen | setlocal wrap linebreak colorcolumn=0')
-
-#vim.command('echo AngryReviewerList')
-# vim.command('call setqflist([], \' \', {\'lines\': AngryReviewerList})')
-# vim.command('copen | setlocal wrap linebreak colorcolumn=0')
+# Save results to a variable (Old snippet, might be useful later?)
+# vim_cmd_arg =  '[\'' + '\', \''.join(results).replace('"', '\"') + '\']'
+# vim.command('let b:AngryReviewerList = ' + vim_cmd_arg)
 
 EOF
 
-" return b:AngryReviewerList
-
-
-" IDEA: clear qf list and append elements individually in a loop
-" Inspired by https://stackoverflow.com/a/15276787
-"call setqflist([], 'r')
-"for l:item in b:AngryReviewerList
-"    " echo l:item
-"    " get line number
-"    let l:lnum = matchstr(l:item, '\d\+', 'regex')
-"    let l:qfitem = substitute(l:item, 'Line \d\+\.\s', '', '')
-"    " echo l:qfitem l:lnum
-"    call setqflist([{'bufnr': bufnr(''), 'lnum': l:lnum, 'text': l:qfitem}], 'a')
-"    " sleep 500m
-"endfor
-copen | setlocal wrap linebreak colorcolumn=0
 
 endfunction
 
 command! -nargs=0 AngryReviewer call AngryReviewer()
-nnoremap <leader>ar :AngryReviewer<cr>
+" BJC94: See updated Readme, better to let users set their own mappings
+" nnoremap <leader>ar :AngryReviewer<cr>
 
 syntax match potionComment "SUGGESTIONS FOR YOUR TEXT:"
 highlight link potionComment Comment

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,15 @@ Using [vim-plug](https://github.com/junegunn/vim-plug):
 
     Plug 'anufrievroman/vim-angry-reviewer'
 
-It works without any configuration, but you find documentation as:
+To set a shortcut in `.vimrc`, use
+
+    nnoremap <leader>ar :AngryReviewer<cr>
+
+You can remap the shortcut (for example to <space>r) as:
+
+    nnoremap <space>r :AngryReviewer<cr>
+
+It works without any additional configuration, but you find documentation as:
 
     :h AngryReviewer
 
@@ -22,14 +30,6 @@ It works without any configuration, but you find documentation as:
 Check the currently opened text:
 
     :AngryReviewer
-
-Default keyboard shortcut:
-
-    <leader>ar
-
-You can remap the shortcut (for example to <space>r) as:
-
-    nnoremap <space>r :AngryReviewer<cr>
 
 ## Author and Feedback
 


### PR DESCRIPTION
Hello,

AngryReviewer is a great addition to my Vim setup! Wanted to help add a couple of features and suggest some changes:

1. The output buffer of AngryReviewer is a bit difficult to read and doesn't allow me to jump to different lines as I scan though errors. I modified the end of the python script so that the results appear in the quickfix window in vim (now you can view the errors with `:copen`, navigate errors with `:cnext` and `:cprev`, or switch focus to the quickfix buffer and jump to the selected error/line with `<CR>`)

2. This is a minor point, but I find it to be better practice to instruct users to set their own mappings instead of relying of default mappings provided by plugins. It ensures mappings are consistent and not overridden accidentally, and users can easily refer to one location in their .vimrc to refresh their memory on their mappings. I've commented this out and updated the readme/docs :)