### PR TITLE
Fix incorrectly escaped singlequotes

### DIFF
--- a/plugin/angry-reviewer.vim
+++ b/plugin/angry-reviewer.vim
@@ -1156,7 +1156,7 @@ for result in results:
         lnum = lnum_search[0]
         qfitem = result[lnum_search.end()+2:]  # Clip text following Line xx.\s
 
-    vim.command('call setqflist([{"bufnr": bufnr(""), "lnum": '+lnum+', "text": \''+qfitem+'\'}], "a")')
+    vim.command('call setqflist([{"bufnr": bufnr(""), "lnum": '+lnum+', "text": \''+qfitem.replace("'", "''") +'\'}], "a")')
 
 vim.command('copen | setlocal nonu nornu wrap linebreak colorcolumn=0')
 vim.command('echo "SUGGESTIONS FOR YOUR TEXT GENERATED"')


### PR DESCRIPTION
As described in #4, the line

     vim.command('call setqflist([{"bufnr": bufnr(""), "lnum": '+lnum+',
     "text": \''+qfitem+'\'}], "a")')

can create an incorrectly formatted vim message when `qfitem` has a
single singlequote in it. This replaces `qfitem` with
`qfitem.replace("'", "''")`.

Note that this works due to an oddity of vimscript. In vimscript,
singlequote delimited strings are "literal strings" (:h literal-string).
In these strings, the way to escape a singlequote is with another
singlequote. (I didn't know this before and found this confusing).

This resolves #4.