### PR TITLE
Fix type error parsing AngryReviewerEnglish option

### DIFF
--- a/plugin/angry-reviewer.vim
+++ b/plugin/angry-reviewer.vim
@@ -1992,6 +1992,8 @@ def main(text, english='american'):
 # Read AngryReviewerEnglish option from vim
 try:
     english_opt = vim.vars["AngryReviewerEnglish"]
+    if type(english_opt) == bytes:
+        english_opt = english_opt.decode()
     if english_opt not in ['american', 'british']:
         raise ValueError
 except KeyError:


### PR DESCRIPTION
When I add `let g:AngryReviewerEnglish = 'british'` to my .vimrc, I get `[WARNING] g:AngryReviewerEnglish must be 'american' or 'british', (using american english)`. Apparently, Vim returns the value as bytes rather than a string - I'm guessing Neovim does this differently, or it would have come up before. Calling `decode()` on the return value fixes it for me.